### PR TITLE
do not process KDL/Joint/JointType

### DIFF
--- a/kdl.orogen
+++ b/kdl.orogen
@@ -42,6 +42,7 @@ import_types_from 'kdl/segment.hpp'
 
 
 typekit do
+    remove_types "/KDL/Joint/JointType"
     export_types 'KDL/Joint',
         '/KDL/JntArray',
         '/KDL/Vector',


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/orocos-toolchain/orogen/pull/142

JointType has a Fixed field, which collides with CORBA's IDL "fixed"
keyword. The wrappers already had their own version of the enum, but
KDL's was processed (but not exported) anyways because the JointType
enum appears in joint.hpp. Note that the type was not used as all
KDL types are opaques anyways.

Remove the type explicitely.